### PR TITLE
Faucet security updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-turnstile"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7381ca451b439579a09feb1d41d4b07c0e903bf8c74602b9e95219c40e47b"
+dependencies = [
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,10 +556,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1515,6 +1541,7 @@ name = "hoku_registrar"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cf-turnstile",
  "clap",
  "ethers",
  "hex",
@@ -1665,15 +1692,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.12",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2077,7 +2105,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2725,7 +2753,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper-rustls 0.27.3",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -2876,10 +2904,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
+ "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -2903,9 +2944,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -3040,13 +3081,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3054,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3397,7 +3460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -3408,7 +3471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.82"
+cf-turnstile = "0.2.0"
 clap = { version = "4.1.14", features = ["derive", "env"] }
 ethers = { version = "2.0.14", features = ["ws"] }
 hex = "0.4.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,9 @@ struct Cli {
     /// Wallet private key (ECDSA, secp256k1) used to register new accounts.
     #[arg(short, long, env)]
     private_key: String,
+    /// Cloudflare secret key.
+    #[arg(short, long, env)]
+    ts_secret: String,
     /// HOKU faucet contract address.
     #[arg(long, env)]
     faucet_address: Address,

--- a/src/server/register.rs
+++ b/src/server/register.rs
@@ -1,15 +1,17 @@
 use crate::server::shared::{DefaultSignerMiddleware, Faucet, FaucetEmpty, TooManyRequests};
 use crate::server::{
-    shared::{with_faucet, BadRequest, RegisterRequest},
+    shared::{with_faucet, with_turnstile, BadRequest, RegisterRequest},
     util::log_request_body,
 };
 use anyhow::anyhow;
+use cf_turnstile::{SiteVerifyRequest, TurnstileClient};
 use ethers::prelude::{Address, ContractError, TxHash};
 use ethers::utils::keccak256;
 use once_cell::sync::Lazy;
 use serde_json::json;
-use warp::{Filter, Rejection, Reply};
 use std::net::SocketAddr;
+use std::sync::Arc;
+use warp::{Filter, Rejection, Reply};
 
 static TRY_LATER_SELECTOR: Lazy<Vec<u8>> = Lazy::new(|| keccak256(b"TryLater()")[0..4].into());
 static FAUCET_EMPTY_SELECTOR: Lazy<Vec<u8>> =
@@ -27,6 +29,7 @@ enum DripResult {
 /// Route filter for `/register` endpoint.
 pub fn register_route(
     faucet: Faucet,
+    turnstile: Arc<TurnstileClient>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path("register")
         .and(warp::post())
@@ -34,6 +37,7 @@ pub fn register_route(
         .and(warp::body::json())
         .and(warp::addr::remote())
         .and(with_faucet(faucet))
+        .and(with_turnstile(turnstile))
         .and_then(handle_register)
 }
 
@@ -42,11 +46,12 @@ pub async fn handle_register(
     req: RegisterRequest,
     addr: Option<SocketAddr>,
     faucet: Faucet,
+    turnstile: Arc<TurnstileClient>,
 ) -> anyhow::Result<impl Reply, Rejection> {
     log_request_body("register", &format!("{}", req));
 
     let addr = addr.ok_or(Rejection::from(BadRequest {
-        message: format!("could not resolve ip address"),
+        message: "could not resolve ip address".to_string(),
     }))?;
 
     let to_address = req.address.parse::<Address>().map_err(|e| {
@@ -55,7 +60,32 @@ pub async fn handle_register(
         })
     })?;
 
-    let res = drip(faucet, to_address, addr.ip().to_string(), req.wait).await.map_err(|e| {
+    let validated = turnstile
+        .siteverify(SiteVerifyRequest {
+            response: req.ts_response,
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| {
+            Rejection::from(BadRequest {
+                message: format!("turnstile error: {}", e),
+            })
+        })?;
+
+    if !validated.success {
+        return Err(Rejection::from(BadRequest {
+            message: "turnstile validation failed".to_string(),
+        }));
+    }
+
+    let res = drip(
+        faucet,
+        to_address,
+        vec![to_address.to_string(), addr.ip().to_string()],
+        req.wait,
+    )
+    .await
+    .map_err(|e| {
         Rejection::from(BadRequest {
             message: format!("register error: {}", e),
         })
@@ -75,15 +105,15 @@ pub async fn handle_register(
 async fn drip(
     faucet: Faucet,
     to_address: Address,
-    key: String,
+    keys: Vec<String>,
     wait: Option<bool>,
 ) -> anyhow::Result<DripResult> {
-    let tx = faucet.drip(to_address, key);
+    let tx = faucet.drip(to_address, keys);
     let tx_pending = tx.send().await;
     match tx_pending {
         Ok(tx) => {
             let hash = tx.tx_hash();
-            let wait = if let Some(wait) = wait { wait } else { true };
+            let wait = wait.unwrap_or(true);
             if wait {
                 tx.await?.ok_or(anyhow!("drip did not return a receipt"))?;
                 Ok(DripResult::Success(hash))

--- a/src/server/shared.rs
+++ b/src/server/shared.rs
@@ -1,12 +1,14 @@
 use std::convert::Infallible;
+use std::sync::Arc;
 
+use cf_turnstile::TurnstileClient;
 use ethers::prelude::{abigen, k256::ecdsa::SigningKey, Http, Provider, SignerMiddleware, Wallet};
 use serde::{Deserialize, Serialize};
 use warp::{http::StatusCode, Filter, Rejection, Reply};
 
 abigen!(
     FaucetContract,
-    r#"[{"name": "drip","type": "function","inputs": [{"name": "recipient","type": "address","internalType": "address payable"}, {"name": "key","type": "string","internalType": "string"}],"outputs": [],"stateMutability": "nonpayable"}]"#
+    r#"[{"name": "drip","type": "function","inputs": [{"name": "recipient","type": "address","internalType": "address payable"}, {"internalType":"string[]","name":"keys","type":"string[]"}],"outputs": [],"stateMutability": "nonpayable"}]"#
 );
 
 pub type DefaultSignerMiddleware = SignerMiddleware<Provider<Http>, Wallet<SigningKey>>;
@@ -17,6 +19,8 @@ pub type Faucet = FaucetContract<DefaultSignerMiddleware>;
 pub struct RegisterRequest {
     /// The address to register.
     pub address: String,
+    /// The Cloudflare Turnstile response to validate.
+    pub ts_response: String,
     /// Whether to wait for the transaction to complete.
     /// Default is true.
     pub wait: Option<bool>,
@@ -61,12 +65,12 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
         (StatusCode::NOT_FOUND, "not found".to_string())
     } else if let Some(e) = err.find::<BadRequest>() {
         (StatusCode::BAD_REQUEST, e.message.clone())
-    } else if let Some(_) = err.find::<TooManyRequests>() {
+    } else if err.find::<TooManyRequests>().is_some() {
         (
             StatusCode::TOO_MANY_REQUESTS,
             "too many requests".to_string(),
         )
-    } else if let Some(_) = err.find::<FaucetEmpty>() {
+    } else if err.find::<FaucetEmpty>().is_some() {
         (StatusCode::SERVICE_UNAVAILABLE, "faucet empty".to_string())
     } else if let Some(e) = err.find::<warp::filters::body::BodyDeserializeError>() {
         (
@@ -97,4 +101,11 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
 /// Filter to pass the faucet to the request handler.
 pub fn with_faucet(faucet: Faucet) -> impl Filter<Extract = (Faucet,), Error = Infallible> + Clone {
     warp::any().map(move || faucet.clone())
+}
+
+/// Filter to pass the Cloudflare Turnstile client to the request handler.
+pub fn with_turnstile(
+    turnstile: Arc<TurnstileClient>,
+) -> impl Filter<Extract = (Arc<TurnstileClient>,), Error = Infallible> + Clone {
+    warp::any().map(move || turnstile.clone())
 }


### PR DESCRIPTION
This PR contains updates to integrate with the changes in https://github.com/hokunet/contracts/pull/36, which means passing the rate limiting lookup keys we want to use to the contract `drip` call ourselves. We'll use the caller's IP address as well as the recipient wallet address.

It also integrates with [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/) to make sure that callers are human.

This is pretty straight forward, but I had to use `Arc` which is something I'm not very familiar with yet in Rust, so take a look at that please.

I've also had a hard time testing out the full stack locally because of some difficulties running localnet, but I wanted to get this out asap so we can at least start discussing it.