### PR TITLE
fix: use arc to share nonce manager instance

### DIFF
--- a/src/server/shared.rs
+++ b/src/server/shared.rs
@@ -15,7 +15,7 @@ abigen!(
 );
 
 pub type DefaultSignerMiddleware =
-    SignerMiddleware<NonceManagerMiddleware<Provider<Http>>, Wallet<SigningKey>>;
+    SignerMiddleware<Arc<NonceManagerMiddleware<Provider<Http>>>, Wallet<SigningKey>>;
 pub type Faucet = FaucetContract<DefaultSignerMiddleware>;
 
 /// Drip request.


### PR DESCRIPTION
The goal here is to share a single nonce manager (and it's internal state) amongst many threads that are handling http requests. 