### PR TITLE
feat: Add serializing middleware to prevent nonce errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,6 +2690,7 @@ name = "recall_registrar"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cf-turnstile",
  "clap",
  "ethers",
@@ -2704,6 +2705,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stderrlog",
+ "thiserror",
  "tokio",
  "warp",
  "warp-real-ip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ warp-real-ip = "0.2.0"
 # depending on the same _without_ the "vendored" feature, because then the Docker build for
 # for ARM64 on AMD64 will fail, it won't find the OpenSSL installation.
 openssl = { version = "0.10", features = ["vendored"] }
+async-trait = "0.1.81"
+thiserror = "1.0.63"

--- a/src/server/shared.rs
+++ b/src/server/shared.rs
@@ -232,7 +232,7 @@ where
         {
             let mut running = self.txn_running.lock().map_err(|_| Self::Error::MutexLockError)?;
             while *running {
-                running = self.condvar.wait(running).unwrap();
+                running = self.condvar.wait(running).map_err(|_| Self::Error::MutexLockError)?;
             }
             *running = true;
         }
@@ -241,7 +241,7 @@ where
 
         // Wake up the next thread waiting to send a txn
         {
-            let mut running = self.txn_running.lock().unwrap(); // todo no unwrap
+            let mut running = self.txn_running.lock().map_err(|_| Self::Error::MutexLockError)?;
             *running = false;
             self.condvar.notify_one();
         }

--- a/src/server/shared.rs
+++ b/src/server/shared.rs
@@ -161,6 +161,9 @@ pub enum SerializingMiddlewareError<M: Middleware> {
     /// Thrown when the internal middleware errors
     #[error("{0}")]
     MiddlewareError(M::Error),
+
+    #[error("Not Implemented")]
+    NotImplemented,
 }
 
 impl<M: Middleware> MiddlewareError for SerializingMiddlewareError<M> {
@@ -173,6 +176,7 @@ impl<M: Middleware> MiddlewareError for SerializingMiddlewareError<M> {
     fn as_inner(&self) -> Option<&Self::Inner> {
         match self {
             SerializingMiddlewareError::MiddlewareError(e) => Some(e),
+            _ => None,
         }
     }
 }
@@ -193,10 +197,11 @@ where
 
     async fn fill_transaction(
         &self,
-        tx: &mut TypedTransaction,
-        block: Option<BlockId>,
+        _: &mut TypedTransaction,
+        _: Option<BlockId>,
     ) -> Result<(), Self::Error> {
-        Ok(self.inner().fill_transaction(tx, block).await.map_err(MiddlewareError::from_err)?)
+        Err(Self::Error::NotImplemented)
+        //Ok(self.inner().fill_transaction(tx, block).await.map_err(MiddlewareError::from_err)?)
     }
 
     /// Signs and broadcasts the transaction. The optional parameter `block` can be passed so that

--- a/src/server/shared.rs
+++ b/src/server/shared.rs
@@ -246,6 +246,11 @@ where
         &self.inner
     }
 
+    /// This fails because if this code path is used and passed down to the NonceManagerMiddleware,
+    /// then the nonce generation gets separated from txn execution and it becomes harder to 
+    /// serialize things in a way that avoids nonce errors.  Currently we don't use this function 
+    /// in our code, so just avoiding that problem for now and relying on the path where the nonce
+    /// gets set in send_transaction.
     async fn fill_transaction(
         &self,
         _: &mut TypedTransaction,


### PR DESCRIPTION
This adds an additional middleware to the Ethers Provider client that serializes all network requests